### PR TITLE
More shorter syntax to use processors

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ grunt.initConfig({
     options: {
       map: true,
       processors: [
-        require('autoprefixer-core')({browsers: 'last 1 version'}).postcss
-        require('csswring').postcss
+        require('autoprefixer-core')({browsers: 'last 1 version'})
+        require('csswring')
       ]
     },
     dist: {


### PR DESCRIPTION
If use set `object` to `PostCSS#use` it try to get `postcss` property. So we can use more shorter syntax.
