### PR TITLE
Log a console error instead of grunt.fail for no source files

### DIFF
--- a/tasks/postcss.js
+++ b/tasks/postcss.js
@@ -67,7 +67,7 @@ module.exports = function(grunt) {
 
         this.files.forEach(function(f) {
             if (!f.src.length) {
-                return grunt.fail.warn('No source files were found.');
+                return grunt.log.error('No source files were found.');
             }
 
             f.src


### PR DESCRIPTION
The rationale is that a developer could be using the same Gruntfile for multiple
projects and one or more may not have CSS files. In this case, we shouldn't fail
the build run if postcss bails out for having nothing to do.

Fixes https://github.com/nDmitry/grunt-postcss/issues/14

@nDmitry 