### PR TITLE
Fix for annotation paths

### DIFF
--- a/tasks/postcss.js
+++ b/tasks/postcss.js
@@ -30,7 +30,11 @@ module.exports = function(grunt) {
      * @returns {string}
      */
     function getSourcemapPath(to) {
-        return path.join(options.map.annotation, path.basename(to)) + '.map';
+        if (options.map.annotation.match(/[\/\\]$/)) {
+            return path.join(options.map.annotation, path.basename(to)) + '.map';
+        } else {
+            return options.map.annotation;
+        }
     }
 
     /**
@@ -136,7 +140,7 @@ module.exports = function(grunt) {
                         var mapDest = dest + '.map';
 
                         if (typeof options.map.annotation === 'string') {
-                            mapDest = getSourcemapPath(dest);
+                            mapDest = path.join(path.dirname(dest), getSourcemapPath(dest));
                         }
 
                         grunt.file.write(mapDest, result.map.toString());


### PR DESCRIPTION
I think in the commit of issue #28 there's a little bug. _postcss_ needs the path for the annotation relative to the stylesheet that is output but `` grunt.file.write`` writes relative to grunt working directory.

In addition I have added the possibility to set the annotation either to a sourcemap filename (as _postcss_'s default behavior) or a directory (path ends with ’’/’’ for use with multiple source files).