### PR TITLE
Write to correct location when a directory path is given in annotation

### DIFF
--- a/tasks/postcss.js
+++ b/tasks/postcss.js
@@ -136,7 +136,7 @@ module.exports = function(grunt) {
                         var mapDest = dest + '.map';
 
                         if (typeof options.map.annotation === 'string') {
-                            mapDest = getSourcemapPath(dest);
+                            mapDest = path.join(path.dirname(dest), getSourcemapPath(dest));
                         }
 
                         grunt.file.write(mapDest, result.map.toString());


### PR DESCRIPTION
_(Split of #30 into two different PRs)_

I think in the commit of issue #28 there's a little bug. postcss needs the path for the annotation relative to the stylesheet that is output but grunt.file.write writes relative to grunt working directory.