### PR TITLE
Allow directory path and filename for annotation

### DIFF
--- a/tasks/postcss.js
+++ b/tasks/postcss.js
@@ -30,7 +30,11 @@ module.exports = function(grunt) {
      * @returns {string}
      */
     function getSourcemapPath(to) {
-        return path.join(options.map.annotation, path.basename(to)) + '.map';
+        if (options.map.annotation.match(/[\/\\]$/)) {
+            return path.join(options.map.annotation, path.basename(to)) + '.map';
+        } else {
+            return options.map.annotation;
+        }
     }
 
     /**


### PR DESCRIPTION
_(Split of #30 into two different PRs)_

This adds the possibility to set the annotation either to a sourcemap filename (as postcss's default behavior) or a directory (path ends with ’’/’’ for use with multiple source files).

_(See #30 for discussion on it)_