### PR TITLE
Annotation path when generated on windows

### DIFF
--- a/tasks/postcss.js
+++ b/tasks/postcss.js
@@ -45,7 +45,7 @@ module.exports = function(grunt) {
         }
 
         if (typeof options.map.annotation === 'string') {
-            annotation = path.relative(path.dirname(to), getSourcemapPath(to));
+            annotation = path.relative(path.dirname(to), getSourcemapPath(to)).replace(/\\/g, '/');
         }
 
         return annotation;


### PR DESCRIPTION
With fixing it "the another way" round in #32 we get the problem that the ``to`` path on windows normally has backslashes. ``path.dirname(to)`` returns a path with slashes and ``getSourcemapPath(to)`` one with backslashes. ``path.relative()`` seems to handle this ok, but returns a backslash path. Of course we need a slash delimiter in the sourcemap annotation as there it is handled as an url.

The patch here might be a bit hackish but works. (``path.posix.relative()`` doesn't help in our case)