### PR TITLE
Use NodeJS >=0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - "0.10"
   - "0.12"
   - "4"
   - "5"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "repository": "nDmitry/grunt-postcss",
   "license": "MIT",
   "engines": {
-    "node": ">= 0.10.0"
+    "node": ">= 0.12.0"
   },
   "scripts": {
     "test": "grunt test"


### PR DESCRIPTION
PostCSS requires NodeJS v.12.0 or greater, grunt-postcss should follow suit to satisfy dependancies

https://github.com/postcss/postcss/blob/master/package.json#L6