### PR TITLE
Add npm version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # grunt-postcss
+[![NPM Version](https://img.shields.io/npm/v/grunt-postcss.svg?style=flat)](https://npmjs.org/package/grunt-postcss)
 [![Build Status](https://travis-ci.org/nDmitry/grunt-postcss.png?branch=master)](https://travis-ci.org/nDmitry/grunt-postcss)
 [![Dependency Status](https://david-dm.org/nDmitry/grunt-postcss.png)](https://david-dm.org/nDmitry/grunt-postcss)
 


### PR DESCRIPTION
Result can be seen here:
https://github.com/danyshaanan/grunt-postcss/tree/patch-1

Badge links to the package's npm page:
https://www.npmjs.com/package/grunt-postcss