### PR TITLE
Add an ability to use options.processor as a function

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,10 @@ require('postcss-plugin')({option: value})
 ### Plugin options
 
 #### options.processors
-Type: `Array`
+Type: `Array|Function`
 Default value: `[]`
 
-An array of PostCSS compatible post-processors.
+An array of PostCSS compatible post-processors. You can also use a function that returns an array of PostCSS post-processors.
 
 #### options.map
 Type: `Boolean|Object`

--- a/tasks/postcss.js
+++ b/tasks/postcss.js
@@ -97,7 +97,11 @@ module.exports = function(grunt) {
             issues: 0
         };
 
-        processor = postcss(options.processors);
+        if (typeof options.processor === 'function') {
+            processor = postcss(options.processors.call());
+        } else {
+            processor = postcss(options.processors);
+        }
 
         var done = this.async();
 


### PR DESCRIPTION
Hi Dmitry. What do you think about ability to use a function in `options.processor`? In this case it will be possible to configure a list of PostCSS post-processors dynamically (depending on Grunt environment etc.). Thanks for such a great plugin, anyway!
