### PR TITLE
Dont run one postcss instance parallel

### DIFF
--- a/tasks/postcss.js
+++ b/tasks/postcss.js
@@ -120,6 +120,11 @@ module.exports = function(grunt) {
                 grunt.log.error('No source files were found.');
 
                 return done();
+
+            // This check shall not apply for configs without destination
+            // (in place processsing).
+            } else if (src.length > 1 && f.dest) {
+                grunt.log.warn("Multiple source files with one destination file configured. All files would write to that *one* destination file.\nThe configured file set is: " + f.src.join(", ") + " => " + f.dest + ".");
             }
 
             Array.prototype.push.apply(tasks, src.map(function(filepath) {


### PR DESCRIPTION
When configuring multiple files for processing (depending on the plugin) the resulting files might be garbage since they share the same processor instance and do not wait until the processing finished.

Example config when using the processor [postcss-preset-env](https://github.com/csstools/postcss-preset-env):
```
files: [{
	src: "input/foo.css",
	dest: "target/foo.css"
},
{
	src: "input/bar.css",
	dest: "target/bar.css"
}]
```

### input/foo.css
```
:root {
	--foo: #333;
}

.moo {
	color: var(--foo);
}
```

### input/bar.css
```
:root {
	--foo: #666;
}
```

### target/foo.css
```
:root {
	--foo: #333;
}

.moo {
	color: #666;
	color: var(--foo);
}
```

Note the "fallback" "color" style is "#666", originated from the bar.css file.

This is probably due to the fact that an internal variables dictionary changed due to the second file while processing the first was not complete yet.

The current implementation calls `process()` in a loop while not waiting for their returned promise to fullfill.

The new implementation uses a reducer to chain the promises together.

A warning was added too to inform the developers if they've configured multiple source files with *one* destination (in place editing), which is not sensible.